### PR TITLE
mod_dialplan_asterisk usage.

### DIFF
--- a/templates/conf/dialplan/default.xml
+++ b/templates/conf/dialplan/default.xml
@@ -747,6 +747,18 @@
       </condition>
     </extension>
 
+
+    <extension name="Asterisk">
+      <condition field="destination_number" expression="^9200$">
+	<action application="answer"/>
+	<action application="sleep" data="500"/>
+	<action application="playback" data="ivr/ivr-asterisk_like_syphilis.wav"/>
+	<action application="sleep" data="500"/>
+	<!-- <action application="transfer" data="$1 asterisk default"/> -->
+        <action application="execute_extension" data="$1 asterisk default"/>
+      </condition>
+    </extension>
+
     <!-- install zrtp_agent.lua into scripts (ZRTP == 9787) -->
     <extension name="zrtp_enrollement">
       <condition field="destination_number" expression="^9787$">

--- a/templates/conf/extensions.conf
+++ b/templates/conf/extensions.conf
@@ -18,4 +18,9 @@ exten => ~^(18(0{2}|8{2}|7{2}|6{2})\d{7})$,n,bridge(${enum_auto_route})
 caller_id_number => 2137991400,n,Goto(default|music) 
 ${sip_from_user} => bill,n,Goto(default|music)
 
+[Lenny]
+exten => talk,1,Set(i=${IF($["0${i}"="016"]?7:$[0${i}+1])})
+same => n,ExecIf($[${i}=1]?MixMonitor(${UNIQUEID}.wav))
+same => n,Playback(Lenny/Lenny${i})
+same => n,BackgroundDetect(Lenny/backgroundnoise,1500)
 


### PR DESCRIPTION
Extension 9200 routes to asterisk default dialplan.

Added Lenny dialplan, but it doesn't seem to work, but I didn't have the sound files in place, so maybe that's why.

Lenny dialplan stolen from: http://www.crosstalksolutions.com/howto-pwn-telemarketers-with-lenny/